### PR TITLE
Remove else in exhaustive case over enums

### DIFF
--- a/nimcuda/cuda_occupancy.nim
+++ b/nimcuda/cuda_occupancy.nim
@@ -458,8 +458,6 @@ proc cudaOccSMemPerMultiprocessor*(limit: ptr csize;
       bytes = sharedMemPerMultiprocessorHigh
     of CACHE_PREFER_L1:
       bytes = sharedMemPerMultiprocessorLow
-    else:
-      bytes = sharedMemPerMultiprocessorHigh
   of 3: ##  Kepler supports 16KB, 32KB, or 48KB partitions for L1. The rest
       ##  is shared memory.
       ##
@@ -473,9 +471,8 @@ proc cudaOccSMemPerMultiprocessor*(limit: ptr csize;
                          ##
       bytes = (sharedMemPerMultiprocessorHigh + sharedMemPerMultiprocessorLow) div
           2
-    else:
-      bytes = sharedMemPerMultiprocessorHigh
-  of 5, 6:                      ##  Maxwell and Pascal have dedicated shared memory.
+  of 5, 6: 
+        ##  Maxwell and Pascal have dedicated shared memory.
         ##
     bytes = sharedMemPerMultiprocessorHigh
   else:


### PR DESCRIPTION
Remove else from exhaustive case statements.  In Nim [0.20.0](https://nim-lang.org/blog/2019/06/06/version-0200-released.html) onward, doing an else when switching over an enum after covering all cases will result in an error.